### PR TITLE
Makes the example in README.rst more explicit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ example:
 
 Example walkthrough
 -------------------
-1. Launch osqueryi from a terminal window. When osqueryi is run without any
+1. Launch ``osqueryi`` from a terminal window. When osqueryi is run without any
 options it will create and connect to a unix socket file in $HOME/.osquery/shell.em.
 
 2. Copy the following code into a file named example.py
@@ -66,7 +66,7 @@ This will register a table called "foobar" that will
 return two rows.
 
 3. Run the example.py script using the --socket option to specify connecting
-to the socket file in your home directory. python example.py --socket ~/.osquery/shell.em
+to the socket file in your home directory. ``python example.py --socket ~/.osquery/shell.em``
 
 4. In the running osqueryi window, enter the follow query:
 

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Example walkthrough
 -------------------
 1. Launch osqueryi from a terminal window. When osqueryi is run without any
 options it will create and connect to a unix socket file in $HOME/.osquery/shell.em.
+
 2. Copy the following code into a file named example.py
 
 .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,12 @@ via a simple, robust plugin and extensions API. This project contains the offici
 Python bindings for creating osquery extensions in Python. Consider the following
 example:
 
+Example walkthrough
+-------------------
+1. Launch osqueryi from a terminal window. When osqueryi is run without any
+options it will create and connect to a unix socket file in $HOME/.osquery/shell.em.
+2. Copy the following code into a file named example.py
+
 .. code-block:: python
 
   import osquery
@@ -55,8 +61,13 @@ example:
       osquery.start_extension(name="my_awesome_extension",
                               version="1.0.0",)
 
-This will register a table called "foobar". As you can see, the table will
-return two rows:
+This will register a table called "foobar" that will
+return two rows.
+
+3. Run the example.py script using the --socket option to specify connecting
+to the socket file in your home directory. python example.py --socket ~/.osquery/shell.em
+
+4. In the running osqueryi window, enter the follow query:
 
 .. code-block:: none
 
@@ -68,6 +79,7 @@ return two rows:
   | bar | baz |
   +-----+-----+
   osquery>
+
 
 
 This is obviously a contrived example, but it's easy to imagine the


### PR DESCRIPTION
Since I had to ask a couple questions to make the example in the README work I thought it might be a good idea to add more text to the README. This version explicitly lays out the steps to implement the sample table by running `osqueryi`, and running the python script with the `--socket` option.