### PR TITLE
Moved travis workers to the sudoless environment and enabled caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: python
+sudo: false
+cache:
+  directories:
+    - $HOME/.cache/pip
 python:
   - 2.6
   - 2.7


### PR DESCRIPTION
The sudoless workers boot faster and have caching enabled for them for public repositories.