### PR TITLE
Update TablePlugin to use 1.7.5 API

### DIFF
--- a/osquery/__init__.py
+++ b/osquery/__init__.py
@@ -4,7 +4,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 __title__ = "osquery"
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "osquery developers"
 __license__ = "BSD"
 __copyright__ = "Copyright 2015 Facebook"

--- a/osquery/management.py
+++ b/osquery/management.py
@@ -144,8 +144,8 @@ def parse_cli_params():
         help="Enable verbose informational messages")
     return parser.parse_args()
 
-def start_extension(name="<unknown>", version="0.0.0", sdk_version="1.4.4",
-                    min_sdk_version="1.4.4"):
+def start_extension(name="<unknown>", version="0.0.0", sdk_version="1.7.5",
+                    min_sdk_version="1.7.5"):
     """Start your extension by communicating with osquery core and starting
     a thrift server.
 

--- a/osquery/table_plugin.py
+++ b/osquery/table_plugin.py
@@ -60,8 +60,10 @@ class TablePlugin(BasePlugin):
         routes = []
         for column in self.columns():
             route = {
+                "id": "column",
                 "name": column.name,
                 "type": column.type,
+                "op": "0",
             }
             routes.append(route)
         return routes


### PR DESCRIPTION
osquery version 1.7.5 has breaking TablePlugin API changes. The new version requires "id" and "op" within route information for table plugins.