### PR TITLE
Limit TravisCI to Python 2x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,7 @@ cache:
 python:
   - 2.6
   - 2.7
-  - 3.2
-  - 3.3
-  - 3.4
-  - 3.5
   - pypy
-  - pypy3
-  - nightly
 install:
   - pip install -r requirements.txt
 script:


### PR DESCRIPTION
The setup metadata only mentions supporting Python 2x, thus only run tests on CI infrastructure for the respective versions.