### PR TITLE
extensions: Add watchdog thread and open retries

### DIFF
--- a/osquery/__init__.py
+++ b/osquery/__init__.py
@@ -4,7 +4,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 __title__ = "osquery"
-__version__ = "1.8.0"
+__version__ = "2.2.0"
 __author__ = "osquery developers"
 __license__ = "BSD"
 __copyright__ = "Copyright 2015 Facebook"

--- a/osquery/extension_client.py
+++ b/osquery/extension_client.py
@@ -8,6 +8,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import time
+
 from thrift.protocol import TBinaryProtocol
 from thrift.transport import TSocket
 from thrift.transport import TTransport
@@ -41,9 +43,18 @@ class ExtensionClient(object):
         if self._transport:
             self._transport.close()
 
-    def open(self):
+    def open(self, timeout=1, interval=0.2):
         """Attempt to open the UNIX domain socket"""
-        self._transport.open()
+        delay = 0
+        while delay < timeout:
+            try:
+                self._transport.open()
+                return True
+            except TTransport.TTransportException:
+                pass
+            delay += interval
+            time.sleep(interval)
+        return False
 
     def extension_manager_client(self):
         """Return an extension manager (osquery core) client."""

--- a/osquery/extension_manager.py
+++ b/osquery/extension_manager.py
@@ -8,11 +8,18 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import sys
+import os
+import threading
+import time
 
 from osquery.extensions.Extension import Iface
 from osquery.extensions.ttypes import ExtensionResponse, ExtensionStatus
 from osquery.singleton import Singleton
+
+def shutdown_request(code, timeout=1):
+    """A delayed shutdown request."""
+    time.sleep(timeout)
+    os._exit(code)
 
 class ExtensionManager(Singleton, Iface):
     """The thrift server for handling extension requests
@@ -64,7 +71,10 @@ class ExtensionManager(Singleton, Iface):
 
     def shutdown(self):
         """The osquery extension manager requested a shutdown"""
-        sys.exit(0)
+        rt = threading.Thread(target=shutdown_request, args=(0,))
+        rt.daemon = True
+        rt.start()
+        return ExtensionStatus(code=0, message="OK")
 
     def registry(self):
         """Accessor for the internal _registry member variable"""


### PR DESCRIPTION
This adds two features:
- Add a thread when the extension manager is started. This watches for the osquery socket to stop.
- Start a thread when the `shutdown` API request occurs. The thread will stop the process within a second.
