### PR TITLE
Disable thrift module logging

### DIFF
--- a/osquery/__init__.py
+++ b/osquery/__init__.py
@@ -4,7 +4,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 __title__ = "osquery"
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 __author__ = "osquery developers"
 __license__ = "BSD"
 __copyright__ = "Copyright 2015 Facebook"


### PR DESCRIPTION
This attempts to disable the log messages from the `thrift` module. It also adds a 1 second default interval for checking health.