### PR TITLE
setup: Add future as a dependency for pip installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(name=TITLE,
       install_requires=[
           "thrift>=0.10",
           "argparse>=1.1",
+          "future",
       ],
       test_suite="tests",
       cmdclass={


### PR DESCRIPTION
Small bugfix for `pip`, `future` is needed for `builtins`.