### PR TITLE
bug: fixing windows extensions not sending responses

### DIFF
--- a/osquery/TPipe.py
+++ b/osquery/TPipe.py
@@ -32,7 +32,7 @@ class TPipeBase(TTransportBase):
         in the same way
         """
         if self._handle is not None:
-            win32file.CloseHandle(self._handle)
+            win32pipe.DisconnectNamedPipe(self._handle)
             self._handle = None
 
 
@@ -227,6 +227,6 @@ class TPipeServer(TPipeBase, TServerTransportBase):
         attempts are successful
         """
         if self._handle is not None:
-            win32pipe.DisconnectNamedPipe(self._handle)
+            super(TPipe, self).close()
             win32file.CloseHandle(self._handle)
             self._handle = None


### PR DESCRIPTION
The logical fix I had added to correctly disconnect the pipe server was invalid and was causing queries against python extensions to fail. I updated the logic to ensure the client only ever disconnects, which I believe is the correct logic. I'll update with a handle leak test tomorrow to ensure this is the case.