### PR TITLE
management: Fix socket fd leak

### DIFF
--- a/osquery/__init__.py
+++ b/osquery/__init__.py
@@ -4,7 +4,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 __title__ = "osquery"
-__version__ = "3.0.5"
+__version__ = "3.0.6"
 __author__ = "osquery developers"
 __license__ = "BSD"
 __copyright__ = "Copyright 2015 Facebook"


### PR DESCRIPTION
It looks like this implementation has always leaked a file descriptor. When it was changed to support Windows it started leaking two descriptors on macOS and Linux.

This fixes the bug by closing the descriptor in the deconstructor.