### PR TITLE
travis: Remove python 3.3 and 3.4 and add 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ cache:
     - $HOME/.cache/pip
 python:
   - 2.7
-  - 3.3
-  - 3.4
   - 3.6
+  - 3.7
   - pypy
   - pypy3
 install:


### PR DESCRIPTION
It looks like 3.3 is no longer hosted and thus the TravisCI tests fail.