### PR TITLE
Add pywin32 for Windows platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,9 @@ setup(name=TITLE,
           "argparse>=1.1",
           "future",
       ],
+      extras_require={
+          ':sys_platform == "win32"': ['pywin32'],
+      }
       test_suite="tests",
       cmdclass={
           "generate": GenerateThriftCommand,

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(name=TITLE,
       ],
       extras_require={
           ':sys_platform == "win32"': ['pywin32'],
-      }
+      },
       test_suite="tests",
       cmdclass={
           "generate": GenerateThriftCommand,


### PR DESCRIPTION
Trying to fix the following dependency issue on Windows platform 😄 

```
>>> import osquery
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\fakepath\AppData\Local\Programs\Python\Python37\lib\site-packages\osquery\__init__.py", line 34, in <module>
    from osquery.extension_client import DEFAULT_SOCKET_PATH, ExtensionClient, \
  File "C:\Users\fakepath\AppData\Local\Programs\Python\Python37\lib\site-packages\osquery\extension_client.py", line 25, in <module>
    from osquery.TPipe import TPipe
  File "C:\Users\fakepath\AppData\Local\Programs\Python\Python37\lib\site-packages\osquery\TPipe.py", line 11, in <module>
    import win32event
ModuleNotFoundError: No module named 'win32event'
```