### PR TITLE
WINDOWS_BINARY_PATH Update

### DIFF
--- a/osquery/management.py
+++ b/osquery/management.py
@@ -42,11 +42,13 @@ if sys.platform == WINDOWS_PLATFORM:
     # We bootleg our own version of Windows pipe coms
     from osquery.TPipe import TPipe
     from osquery.TPipe import TPipeServer
+    if os.path.exists(os.environ["PROGRAMDATA"] + "\\osquery\\osqueryd\\osqueryd.exe"):
+        WINDOWS_BINARY_PATH = os.environ["PROGRAMDATA"] + "\\osquery\\osqueryd\\osqueryd.exe"
+    if os.path.exists(os.environ["PROGRAMW6432"] + "\\osquery\\osqueryd\\osqueryd.exe"):
+        WINDOWS_BINARY_PATH = os.environ["PROGRAMW6432"] + "\\osquery\\osqueryd\\osqueryd.exe"
 
 DARWIN_BINARY_PATH = "/usr/local/bin/osqueryd"
 LINUX_BINARY_PATH = "/usr/bin/osqueryd"
-WINDOWS_BINARY_PATH = "C:\\ProgramData\\osquery\\osqueryd\\osqueryd.exe"
-
 
 class SpawnInstance(object):
     """Spawn a standalone osquery instance"""


### PR DESCRIPTION
Update to WINDOWS_BINARY_PATH so that this works with Chocolatey installs of osQuery (those go to %PROGRAMDATA%) or installs from osquery MSI's (those end up in %ProgramFiles%). Also make use of OS environment variables in case the system isn't installed on the default C:\