### PR TITLE
Fix for double-JSON-encoding of table generation contexts (#77)

### DIFF
--- a/osquery/table_plugin.py
+++ b/osquery/table_plugin.py
@@ -39,7 +39,7 @@ class TablePlugin(with_metaclass(ABCMeta, BasePlugin)):
         if context["action"] == "generate":
             ctx = {}
             if "context" in context:
-                ctx = json.dumps(context["context"])
+                ctx = json.loads(context["context"])
             rows = self.generate(ctx)
             for i, row in enumerate(rows):
                 for key, value in row.items():


### PR DESCRIPTION
As described in issue #77, the context information passed to a table plugin's `generate()` method is (a) inconveniently double-encoded and (b) inconsistent in its data type (since it can either be a double-encoded string or an empty dictionary). This PR fixes this to always pass a dictionary, which will contain the unpacked context information if it was provided in the call.