### PR TITLE
'fix the warnings from 'is not 0' to '!= 0' in management.py

### DIFF
--- a/osquery/management.py
+++ b/osquery/management.py
@@ -191,7 +191,7 @@ def start_watcher(client, interval):
     try:
         while True:
             status = client.extension_manager_client().ping()
-            if status.code is not 0:
+            if status.code != 0:
                 break
             time.sleep(interval)
     except socket.error:
@@ -248,7 +248,7 @@ def start_extension(name="<unknown>",
             message=message,
         )
 
-    if status.code is not 0:
+    if status.code != 0:
         raise ExtensionException(
             code=1,
             message=status.message,
@@ -300,7 +300,7 @@ def deregister_extension():
             message=message,
         )
 
-    if status.code is not 0:
+    if status.code != 0:
         raise ExtensionException(
             code=1,
             message=status.message,


### PR DESCRIPTION
I am working on a project where I am using this python library in a Windows and Linux environment. It is super convenient for getting python to communicate with osqueryd.

I am using this module with Python version 3.9 in my environment and I am receiving the following warnings referencing the management.py file:

```
In [1]: from osquery_interface import OsqueryInterface
c:\users\booboy\.virtualenvs\query_app_inf_osquery-dn8tsr2s\src\osquery\osquery\management.py:186: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if status.code is not 0:
c:\users\booboy\.virtualenvs\query_app_inf_osquery-dn8tsr2s\src\osquery\osquery\management.py:243: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if status.code is not 0:
c:\users\booboy\.virtualenvs\query_app_inf_osquery-dn8tsr2s\src\osquery\osquery\management.py:295: SyntaxWarning: "is not" with a literal. Did you mean "!="?
```

This PR will fix those warnings and replace the `is not 0` with `!= 0`  in the `management.py` file.