### PR TITLE
Fix handling of exceptions when osquery goes away

### DIFF
--- a/osquery/management.py
+++ b/osquery/management.py
@@ -191,13 +191,22 @@ def start_watcher(client, interval):
     try:
         while True:
             status = client.extension_manager_client().ping()
-            if status.code is not 0:
+            if status.code != 0:
+                logging.error("Ping received nonzero status: %d", status)
                 break
             time.sleep(interval)
-    except socket.error:
-        # The socket was torn down.
-        pass
-    os._exit(0)
+
+    except socket.error as e:
+        logging.error("Ping received socket.error: %s", e)
+
+    except TTransport.TTransportException as e:
+        logging.error("Ping received thrift.transport.TTransport.TTransportException: %s", e)
+
+    except Exception as e:
+        logging.error("Ping received unknown exception: %s", e)
+
+    finally:
+        os._exit(1)
 
 
 def start_extension(name="<unknown>",
@@ -248,7 +257,7 @@ def start_extension(name="<unknown>",
             message=message,
         )
 
-    if status.code is not 0:
+    if status.code != 0:
         raise ExtensionException(
             code=1,
             message=status.message,
@@ -300,7 +309,7 @@ def deregister_extension():
             message=message,
         )
 
-    if status.code is not 0:
+    if status.code != 0:
         raise ExtensionException(
             code=1,
             message=status.message,


### PR DESCRIPTION
This resolves an issue where the extension does not shut down if osquery
goes away unexpectedly (without sending a shutdown signal via Thrift).

The scenario could be reliably reproduced by running `osqueryi`,
connecting an extension, and then sending a `SIGKILL` to `osqueryi`. The
exception thrown in the `start_watcher` function would be of type
`thrift.transport.TTransport.TTransportException`, and would cause the
watcher thread to exit without exiting the rest of the program.

This is a possible fix for issues that users have experienced with
extensions reconnecting after the Watchdog kills osquery.