### PR TITLE
Fix 2 issues (related to #57)

### DIFF
--- a/osquery/TPipe.py
+++ b/osquery/TPipe.py
@@ -32,7 +32,7 @@ class TPipeBase(TTransportBase):
         in the same way
         """
         if self._handle is not None:
-            win32pipe.DisconnectNamedPipe(self._handle)
+            win32file.CloseHandle(self._handle)
             self._handle = None
 
 
@@ -227,6 +227,5 @@ class TPipeServer(TPipeBase, TServerTransportBase):
         attempts are successful
         """
         if self._handle is not None:
-            super(TPipe, self).close()
-            win32file.CloseHandle(self._handle)
-            self._handle = None
+            win32pipe.DisconnectNamedPipe(self._handle)
+            super(TPipeBase).close()


### PR DESCRIPTION
Issue 1: in TPipeServer, the CloseHandle call happened on a None _handle after the super() call. Issue 2: Client raises an issue as described in https://github.com/osquery/osquery-python/issues/57, correct call seems to be CloseHandle.

This commit fixes both issues