### PR TITLE
remove argparse as it was moved to the python standard library as of …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(name=TITLE,
       ],
       install_requires=[
           "thrift>=0.10",
-          "argparse>=1.1",
           "future",
       ],
       extras_require={


### PR DESCRIPTION
…python 3.2 and python 2.7