### PR TITLE
remove argparse as it was moved to the python standard library as of python 3.2 and python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(name=TITLE,
       ],
       install_requires=[
           "thrift>=0.10",
-          "argparse>=1.1",
           "future",
       ],
       extras_require={


### PR DESCRIPTION
Including this requirement causes idempotence issues with configuration management systems:
https://www.reddit.com/r/learnpython/comments/uj3dhx/why_does_pip_keep_reinstalling_the_same_version/?rdt=57231

python 3.2 and 2.7 have been end-of-life for several years: https://devguide.python.org/versions/